### PR TITLE
Fix: change an alignment and add a program header in `linkcmds.include`

### DIFF
--- a/linkcmds.include
+++ b/linkcmds.include
@@ -75,7 +75,7 @@ SECTIONS
         _etext = . ;
     } > RAM_CACHED
 
-    .tohost ALIGN(1000) :
+    .tohost ALIGN(4096) :
     {
         *(.tohost) ;
     } > RAM_CACHED

--- a/linkcmds.include
+++ b/linkcmds.include
@@ -26,6 +26,10 @@
  * @file   linkcmds.include
  * @author Cesar Fuguet Tortolero
  */
+PHDRS
+{
+    data_segment PT_LOAD FLAGS(6); /* RW */
+}
 SECTIONS
 {
     .text :
@@ -84,7 +88,7 @@ SECTIONS
         *(.data.cached) ;
         . = ALIGN(8) ;
         _edata_cached = . ;
-    } > RAM_CACHED
+    } > RAM_CACHED :data_segment
 
     .heap ALIGN(64) (NOLOAD) :
     {


### PR DESCRIPTION
This patch remove a RWX warning about the RAM_CACHED section in `ld` and fix an alignment from 1000 to 4096. 